### PR TITLE
chore: automate frontend builds on every push

### DIFF
--- a/.github/workflows/FrontendWorkflow.yml
+++ b/.github/workflows/FrontendWorkflow.yml
@@ -36,3 +36,7 @@ jobs:
       - name: Lint
         run: npm run lint
         working-directory: ./frontend
+      
+      - name: Build
+        run: npm run build
+        working-directory: ./frontend


### PR DESCRIPTION
### Changes Made
- Modified the frontend workflow to trigger builds automatically on every push to enhance development efficiency.

### Context
Previously, the frontend build process was initiated manually. This modification automates the build process, ensuring that builds are triggered automatically whenever changes are pushed to the repository. This improvement streamlines the development workflow and helps maintain a consistent and up-to-date build.

### Checklist
- [x] Verified that builds are triggered automatically on push
